### PR TITLE
refactor: mdx config improvement

### DIFF
--- a/apps/blog/src/App.tsx
+++ b/apps/blog/src/App.tsx
@@ -97,9 +97,9 @@ export default function BlogApp() {
             path="*"
             element={
               <NotFoundSection
-                illustrationSrc={imageSource("/404.svg", "blog", {
+                illustrationSrc={imageSource("blog", {
                   isDevelopment: import.meta.env.MODE === "development",
-                })}
+                })("/404.svg")}
                 renderLink={() => (
                   <Link
                     to="/blog/posts"

--- a/apps/blog/src/App.tsx
+++ b/apps/blog/src/App.tsx
@@ -1,7 +1,7 @@
 import "./App.css";
 import { Navigate, Route, Routes, Link } from "react-router-dom";
 import { SEO, WebsiteJsonLd, PersonJsonLd, NotFoundSection } from "@srf/ui";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "./utils/get-image-source";
 
 import BlogLayout from "./components/layout";
 import PostDetailPage from "./pages/post/post-detail-page";
@@ -97,9 +97,7 @@ export default function BlogApp() {
             path="*"
             element={
               <NotFoundSection
-                illustrationSrc={imageSource("blog", {
-                  isDevelopment: import.meta.env.MODE === "development",
-                })("/404.svg")}
+                illustrationSrc={getImageSource("/404.svg")}
                 renderLink={() => (
                   <Link
                     to="/blog/posts"

--- a/apps/blog/src/components/content-detail-layout.tsx
+++ b/apps/blog/src/components/content-detail-layout.tsx
@@ -1,6 +1,7 @@
 import { useParams, useLocation, Link } from "react-router-dom";
 import type { BaseMeta, ContentItem } from "@/types/contents/common";
-import { extractDateFromMeta, formatDate, imageSource } from "@mfe/shared";
+import { extractDateFromMeta, formatDate } from "@mfe/shared";
+import { getImageSource } from "../utils/get-image-source";
 import { useSerializedMDX } from "@/hooks/use-serialized-mdx";
 import { BlogMDX } from "@/components/mdx/blog-mdx";
 import TableOfContents from "@/components/table-of-contents";
@@ -68,9 +69,7 @@ export function ContentDetailLayout<T extends BaseMeta>({
   if (!item) {
     return (
       <NotFoundSection
-        illustrationSrc={imageSource("blog", {
-          isDevelopment: import.meta.env.MODE === "development",
-        })("/404.svg")}
+        illustrationSrc={getImageSource("/404.svg")}
         renderLink={() => (
           <Link
             to="/blog/posts"

--- a/apps/blog/src/components/content-detail-layout.tsx
+++ b/apps/blog/src/components/content-detail-layout.tsx
@@ -68,9 +68,9 @@ export function ContentDetailLayout<T extends BaseMeta>({
   if (!item) {
     return (
       <NotFoundSection
-        illustrationSrc={imageSource("/404.svg", "blog", {
+        illustrationSrc={imageSource("blog", {
           isDevelopment: import.meta.env.MODE === "development",
-        })}
+        })("/404.svg")}
         renderLink={() => (
           <Link
             to="/blog/posts"

--- a/apps/blog/src/components/mdx/blog-mdx-config.ts
+++ b/apps/blog/src/components/mdx/blog-mdx-config.ts
@@ -9,7 +9,9 @@ import {
  * 런타임 설정
  */
 export const blogRuntimeConfig: RuntimeConfig = {
-  processImageSource: createProcessImageSource("blog"),
+  processImageSource: createProcessImageSource("blog", {
+    isDevelopment: import.meta.env.MODE === "development",
+  }),
   appName: "blog",
 };
 

--- a/apps/blog/src/components/mdx/blog-mdx-config.ts
+++ b/apps/blog/src/components/mdx/blog-mdx-config.ts
@@ -1,23 +1,15 @@
 import { Link } from "react-router-dom";
-import { imageSource } from "@mfe/shared";
-import { isExternalLink } from "@srf/ui";
 import type { RuntimeConfig, SerializeOptions } from "@srf/ui";
-import { createDefaultSerializeOptions } from "@srf/ui";
-
-/**
- * 이미지 소스 처리
- */
-function processImageSource(src: string, appName: string): string {
-  if (isExternalLink(src)) return src;
-  const isDevelopment = import.meta.env.MODE === "development";
-  return imageSource(src, appName as "blog", { isDevelopment });
-}
+import {
+  createDefaultSerializeOptions,
+  createProcessImageSource,
+} from "@srf/ui";
 
 /**
  * 런타임 설정
  */
 export const blogRuntimeConfig: RuntimeConfig = {
-  processImageSource,
+  processImageSource: createProcessImageSource("blog"),
   appName: "blog",
 };
 

--- a/apps/blog/src/utils/get-image-source.ts
+++ b/apps/blog/src/utils/get-image-source.ts
@@ -1,0 +1,10 @@
+import { imageSource } from "@mfe/shared";
+
+/**
+ * Blog 앱용 이미지 소스 생성 함수
+ * 개발/프로덕션 환경에 따라 적절한 호스트 URL을 사용합니다.
+ */
+export const getImageSource = imageSource("blog", {
+  isDevelopment: import.meta.env.MODE === "development",
+});
+

--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -20,9 +20,9 @@ function App() {
           path="*"
           element={
             <NotFoundSection
-              illustrationSrc={imageSource("/404.svg", "portfolio", {
+              illustrationSrc={imageSource("portfolio", {
                 isDevelopment: import.meta.env.MODE === "development",
-              })}
+              })("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/portfolio"

--- a/apps/portfolio/src/App.tsx
+++ b/apps/portfolio/src/App.tsx
@@ -5,7 +5,7 @@ import HomePage from "./pages/home/home-page";
 import ProjectsPage from "./pages/projects/projects-page";
 import ProjectDetailPage from "./pages/project-detail/project-detail-page";
 import { NotFoundSection } from "@srf/ui";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "./utils/get-image-source";
 
 function App() {
   return (
@@ -20,9 +20,7 @@ function App() {
           path="*"
           element={
             <NotFoundSection
-              illustrationSrc={imageSource("portfolio", {
-                isDevelopment: import.meta.env.MODE === "development",
-              })("/404.svg")}
+              illustrationSrc={getImageSource("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/portfolio"

--- a/apps/portfolio/src/components/common/project-card.tsx
+++ b/apps/portfolio/src/components/common/project-card.tsx
@@ -55,9 +55,9 @@ export function ProjectCard({
               className={`relative ${getThumbnailAspectRatio(project.coverAspectRatio)} overflow-hidden`}
             >
               <img
-                src={imageSource(imageSrc, "portfolio", {
+                src={imageSource("portfolio", {
                   isDevelopment: import.meta.env.MODE === "development",
-                })}
+                })(imageSrc)}
                 alt={project.coverAlt || project.title}
                 loading="lazy"
                 decoding="async"

--- a/apps/portfolio/src/components/common/project-card.tsx
+++ b/apps/portfolio/src/components/common/project-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "@/utils/get-image-source";
 import type { ProjectMeta } from "@/entities/project";
 import {
   getFallbackThumbnail,
@@ -55,9 +55,7 @@ export function ProjectCard({
               className={`relative ${getThumbnailAspectRatio(project.coverAspectRatio)} overflow-hidden`}
             >
               <img
-                src={imageSource("portfolio", {
-                  isDevelopment: import.meta.env.MODE === "development",
-                })(imageSrc)}
+                src={getImageSource(imageSrc)}
                 alt={project.coverAlt || project.title}
                 loading="lazy"
                 decoding="async"

--- a/apps/portfolio/src/components/mdx/lib/utils.ts
+++ b/apps/portfolio/src/components/mdx/lib/utils.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { isValidElement } from "react";
-import { imageSource } from "@mfe/shared";
+import { portfolioRuntimeConfig } from "../portfolio-mdx-config";
 import type { ElementWithChildren } from "./types";
 
 export function normalizeClassName(className?: string | string[]): string {
@@ -12,15 +12,16 @@ export function isExternalUrl(url?: string): boolean {
   return url ? /^https?:\/\//i.test(url) || url.startsWith("//") : false;
 }
 
+/**
+ * 이미지 소스 처리 함수
+ * RuntimeConfig의 processImageSource를 사용하여 일관성 유지
+ */
 export function processImageSource(src?: string): string | undefined {
   if (!src) return undefined;
-  if (isExternalUrl(src)) return src;
-
-  // 개발/프로덕션 환경에 따라 적절한 호스트 URL을 사용
-  const isDevelopment = import.meta.env.MODE === "development";
-  return imageSource(src, "portfolio", {
-    isDevelopment,
-  });
+  return portfolioRuntimeConfig.processImageSource(
+    src,
+    portfolioRuntimeConfig.appName,
+  );
 }
 
 export function createImageStyle(width?: number | string, height?: number | string): React.CSSProperties | undefined {

--- a/apps/portfolio/src/components/mdx/portfolio-mdx-config.ts
+++ b/apps/portfolio/src/components/mdx/portfolio-mdx-config.ts
@@ -16,7 +16,9 @@ import type { RuntimeConfig, SerializeOptions } from "@srf/ui";
  * 런타임 설정
  */
 export const portfolioRuntimeConfig: RuntimeConfig = {
-  processImageSource: createProcessImageSource("portfolio"),
+  processImageSource: createProcessImageSource("portfolio", {
+    isDevelopment: import.meta.env.MODE === "development",
+  }),
   appName: "portfolio",
 };
 

--- a/apps/portfolio/src/components/mdx/portfolio-mdx-config.ts
+++ b/apps/portfolio/src/components/mdx/portfolio-mdx-config.ts
@@ -1,27 +1,22 @@
 import { Link } from "react-router-dom";
-import { imageSource } from "@mfe/shared";
 import remarkGfm from "remark-gfm";
 import rehypePrettyCode from "rehype-pretty-code";
 import type { Element } from "hast";
-import { isExternalLink, rehypeUnwrapImages, rehypeSkipMermaid } from "@srf/ui";
-import type { RuntimeConfig, SerializeOptions, RehypePlugin } from "@srf/ui";
-import { createDefaultSerializeOptions } from "@srf/ui";
-
-/**
- * 이미지 소스 처리
- */
-function processImageSource(src: string, appName: string): string {
-  if (isExternalLink(src)) return src;
-
-  const isDevelopment = import.meta.env.MODE === "development";
-  return imageSource(src, appName as "portfolio", { isDevelopment });
-}
+import {
+  rehypeUnwrapImages,
+  rehypeSkipMermaid,
+  createDefaultSerializeOptions,
+  createProcessImageSource,
+  removePlugin,
+  sanitizeMdxSource,
+} from "@srf/ui";
+import type { RuntimeConfig, SerializeOptions } from "@srf/ui";
 
 /**
  * 런타임 설정
  */
 export const portfolioRuntimeConfig: RuntimeConfig = {
-  processImageSource,
+  processImageSource: createProcessImageSource("portfolio"),
   appName: "portfolio",
 };
 
@@ -29,33 +24,6 @@ export const portfolioRuntimeConfig: RuntimeConfig = {
  * 링크 컴포넌트
  */
 export const portfolioLinkComponent = Link;
-
-/**
- * MDX 소스 정제 함수
- * BOM 제거, 줄바꿈 정규화, 중괄호 이스케이프 처리
- */
-export function sanitizeMdxSource(src: string): string {
-  return src
-    .replace(/^\uFEFF/, "")
-    .replace(/\r\n/g, "\n")
-    .replace(/{{/g, "\\{\\{")
-    .replace(/}}/g, "\\}\\}");
-}
-
-/**
- * 플러그인 배열에서 특정 플러그인을 제거하는 유틸리티
- */
-function removePlugin(
-  plugins: RehypePlugin[],
-  targetPlugin: unknown,
-): RehypePlugin[] {
-  return plugins.filter((plugin) => {
-    if (Array.isArray(plugin)) {
-      return plugin[0] !== targetPlugin;
-    }
-    return plugin !== targetPlugin;
-  });
-}
 
 /**
  * rehypePrettyCode 설정

--- a/apps/portfolio/src/pages/home/components/hero-section.tsx
+++ b/apps/portfolio/src/pages/home/components/hero-section.tsx
@@ -1,4 +1,5 @@
 import { motion, useScroll, useTransform } from "framer-motion";
+import { Link } from "react-router-dom";
 import { fadeUp, easeOutCb } from "@/utils/motion";
 
 export function HeroSection() {
@@ -40,51 +41,41 @@ export function HeroSection() {
           만들어갑니다.
         </motion.p>
 
-        {/* 태그 섹션 */}
+        {/* CTA 버튼 */}
         <motion.div
-          className="mt-6 flex flex-wrap gap-2 sm:mt-7"
-          initial="hidden"
-          whileInView="show"
+          className="mt-6 sm:mt-7"
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
           viewport={{ margin: "-10% 0px", once: true }}
-          variants={{
-            hidden: { opacity: 0 },
-            show: {
-              opacity: 1,
-              transition: {
-                staggerChildren: 0.08,
-              },
-            },
+          transition={{
+            delay: 0.2,
+            type: "spring",
+            stiffness: 100,
+            damping: 15,
           }}
         >
-          {[
-            { label: "Frontend", color: "from-blue-500/10 to-cyan-500/10" },
-            { label: "UX", color: "from-blue-500/10 to-indigo-500/10" },
-            { label: "DX", color: "from-purple-500/10 to-pink-500/10" },
-            { label: "협업", color: "from-emerald-500/10 to-teal-500/10" },
-          ].map((tag) => (
-            <motion.span
-              key={tag.label}
-              variants={{
-                hidden: { opacity: 0, y: 8 },
-                show: {
-                  opacity: 1,
-                  y: 0,
-                  transition: {
-                    type: "spring",
-                    stiffness: 100,
-                    damping: 15,
-                    mass: 0.8,
-                  },
-                },
-              }}
-              className="group relative inline-flex items-center rounded-lg border border-[var(--border)] bg-[var(--surface)] px-3 py-1.5 text-xs font-medium text-[var(--fg)] transition-all duration-200 hover:border-[var(--primary)]/30 hover:shadow-sm sm:px-4 sm:py-2 sm:text-sm"
+          <Link
+            to="/portfolio/projects"
+            className="group inline-flex items-center gap-2 rounded-lg border border-[var(--primary)]/30 bg-[var(--primary)]/10 px-5 py-2.5 text-sm font-medium text-[var(--primary)] transition-all duration-200 hover:bg-[var(--primary)]/15 hover:border-[var(--primary)]/50 hover:shadow-sm sm:px-6 sm:py-3 sm:text-base"
+          >
+            <span>프로젝트 둘러보기</span>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+              className="transition-transform duration-200 group-hover:translate-x-1"
             >
-              <span className="relative z-10">{tag.label}</span>
-              <span
-                className={`absolute inset-0 rounded-lg bg-gradient-to-r ${tag.color} opacity-0 transition-opacity duration-200 group-hover:opacity-100`}
+              <path
+                d="M6 12L10 8L6 4"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
-            </motion.span>
-          ))}
+            </svg>
+          </Link>
         </motion.div>
       </div>
     </section>

--- a/apps/portfolio/src/pages/home/components/selected-projects.tsx
+++ b/apps/portfolio/src/pages/home/components/selected-projects.tsx
@@ -9,11 +9,7 @@ interface SelectedProjectsProps {
 export function SelectedProjects({ projects }: SelectedProjectsProps) {
   return (
     <section className="space-y-3">
-      <SectionHeader
-        title="Selected Projects"
-        linkTo="/portfolio/projects"
-        linkText="전체 보기"
-      />
+      <SectionHeader title="주요 프로젝트" />
       <ProjectGrid
         projects={projects}
         renderProject={(project) => <ProjectCard project={project} />}

--- a/apps/portfolio/src/pages/project-detail/components/project-cover.tsx
+++ b/apps/portfolio/src/pages/project-detail/components/project-cover.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "@/utils/get-image-source";
 import type { ProjectMeta } from "@/entities/project";
 import { getFallbackThumbnail } from "@/utils/thumbnail";
 
@@ -26,9 +26,7 @@ export function ProjectCover({ project }: ProjectCoverProps) {
   return (
     <div className="mb-8 flex flex-col items-center">
       <img
-        src={imageSource("portfolio", {
-          isDevelopment: import.meta.env.MODE === "development",
-        })(imageSrc)}
+        src={getImageSource(imageSrc)}
         alt={project.coverAlt || project.title}
         className="h-auto rounded-lg"
         style={{ width: "min(600px, 100%)" }}

--- a/apps/portfolio/src/pages/project-detail/components/project-cover.tsx
+++ b/apps/portfolio/src/pages/project-detail/components/project-cover.tsx
@@ -26,9 +26,9 @@ export function ProjectCover({ project }: ProjectCoverProps) {
   return (
     <div className="mb-8 flex flex-col items-center">
       <img
-        src={imageSource(imageSrc, "portfolio", {
+        src={imageSource("portfolio", {
           isDevelopment: import.meta.env.MODE === "development",
-        })}
+        })(imageSrc)}
         alt={project.coverAlt || project.title}
         className="h-auto rounded-lg"
         style={{ width: "min(600px, 100%)" }}

--- a/apps/portfolio/src/pages/project-detail/project-detail-page.tsx
+++ b/apps/portfolio/src/pages/project-detail/project-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useParams } from "react-router-dom";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "@/utils/get-image-source";
 import { usePortfolioIndex, useProjectMdx } from "@/entities/project";
 import { LoadingSpinner, ErrorMessage } from "@/components/common";
 import { useMdxContent } from "./hooks/use-mdx-content";
@@ -28,9 +28,7 @@ export default function ProjectDetail() {
 
   if (!project) {
     const isDevelopment = import.meta.env.MODE === "development";
-    const illustrationSrc = imageSource("portfolio", {
-      isDevelopment,
-    })("/404.svg");
+    const illustrationSrc = getImageSource("/404.svg");
 
     return (
       <ErrorMessage

--- a/apps/portfolio/src/pages/project-detail/project-detail-page.tsx
+++ b/apps/portfolio/src/pages/project-detail/project-detail-page.tsx
@@ -28,9 +28,9 @@ export default function ProjectDetail() {
 
   if (!project) {
     const isDevelopment = import.meta.env.MODE === "development";
-    const illustrationSrc = imageSource("/404.svg", "portfolio", {
+    const illustrationSrc = imageSource("portfolio", {
       isDevelopment,
-    });
+    })("/404.svg");
 
     return (
       <ErrorMessage

--- a/apps/portfolio/src/utils/get-image-source.ts
+++ b/apps/portfolio/src/utils/get-image-source.ts
@@ -1,0 +1,10 @@
+import { imageSource } from "@mfe/shared";
+
+/**
+ * Portfolio 앱용 이미지 소스 생성 함수
+ * 개발/프로덕션 환경에 따라 적절한 호스트 URL을 사용합니다.
+ */
+export const getImageSource = imageSource("portfolio", {
+  isDevelopment: import.meta.env.MODE === "development",
+});
+

--- a/apps/resume/src/App.tsx
+++ b/apps/resume/src/App.tsx
@@ -3,7 +3,7 @@ import "./App.css";
 import ResumePage from "./pages/resume/resume-page";
 import { NotFoundSection } from "@srf/ui";
 import { ViewportProvider } from "./contexts/viewport-context";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "./utils/get-image-source";
 
 export default function ResumeApp() {
   return (
@@ -14,9 +14,7 @@ export default function ResumeApp() {
           path="*"
           element={
             <NotFoundSection
-              illustrationSrc={imageSource("resume", {
-                isDevelopment: import.meta.env.MODE === "development",
-              })("/404.svg")}
+              illustrationSrc={getImageSource("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/resume"

--- a/apps/resume/src/App.tsx
+++ b/apps/resume/src/App.tsx
@@ -14,9 +14,9 @@ export default function ResumeApp() {
           path="*"
           element={
             <NotFoundSection
-              illustrationSrc={imageSource("/404.svg", "resume", {
+              illustrationSrc={imageSource("resume", {
                 isDevelopment: import.meta.env.MODE === "development",
-              })}
+              })("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/resume"

--- a/apps/resume/src/components/tooltip/keyword-tooltip.tsx
+++ b/apps/resume/src/components/tooltip/keyword-tooltip.tsx
@@ -12,9 +12,9 @@ export function KeywordTooltip({ keyword, imageUrl }: KeywordTooltipProps) {
       content={
         <div>
           <img
-            src={imageSource(imageUrl || "", "resume", {
+            src={imageSource("resume", {
               isDevelopment: import.meta.env.MODE === "development",
-            })}
+            })(imageUrl || "")}
             alt={keyword}
             className={cn(
               "max-w-[calc(28rem-24px)] min-w-[calc(28rem-24px)] min-h-48",

--- a/apps/resume/src/components/tooltip/keyword-tooltip.tsx
+++ b/apps/resume/src/components/tooltip/keyword-tooltip.tsx
@@ -1,5 +1,5 @@
 import { InlineTooltip, cn } from "@srf/ui";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "@/utils/get-image-source";
 
 interface KeywordTooltipProps {
   keyword: string;
@@ -12,9 +12,7 @@ export function KeywordTooltip({ keyword, imageUrl }: KeywordTooltipProps) {
       content={
         <div>
           <img
-            src={imageSource("resume", {
-              isDevelopment: import.meta.env.MODE === "development",
-            })(imageUrl || "")}
+            src={getImageSource(imageUrl || "")}
             alt={keyword}
             className={cn(
               "max-w-[calc(28rem-24px)] min-w-[calc(28rem-24px)] min-h-48",

--- a/apps/resume/src/pages/resume/components/header/index.tsx
+++ b/apps/resume/src/pages/resume/components/header/index.tsx
@@ -62,9 +62,9 @@ function ProfileImage({ profile }: { profile: ResumeData["profile"] }) {
   return (
     <motion.img
       {...fadeUp}
-      src={imageSource(profile.photoUrl, "resume", {
+      src={imageSource("resume", {
         isDevelopment: import.meta.env.MODE === "development",
-      })}
+      })(profile.photoUrl)}
       alt={`${profile.name} 프로필`}
       className={cn(
         "rounded-2xl object-cover border border-[var(--border)] flex-shrink-0",

--- a/apps/resume/src/pages/resume/components/header/index.tsx
+++ b/apps/resume/src/pages/resume/components/header/index.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { cn } from "@srf/ui";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "@/utils/get-image-source";
 
 import type { ResumeData } from "@/service";
 import { Card } from "@/components/card";
@@ -62,9 +62,7 @@ function ProfileImage({ profile }: { profile: ResumeData["profile"] }) {
   return (
     <motion.img
       {...fadeUp}
-      src={imageSource("resume", {
-        isDevelopment: import.meta.env.MODE === "development",
-      })(profile.photoUrl)}
+      src={getImageSource(profile.photoUrl)}
       alt={`${profile.name} 프로필`}
       className={cn(
         "rounded-2xl object-cover border border-[var(--border)] flex-shrink-0",

--- a/apps/resume/src/utils/get-image-source.ts
+++ b/apps/resume/src/utils/get-image-source.ts
@@ -1,0 +1,10 @@
+import { imageSource } from "@mfe/shared";
+
+/**
+ * Resume 앱용 이미지 소스 생성 함수
+ * 개발/프로덕션 환경에 따라 적절한 호스트 URL을 사용합니다.
+ */
+export const getImageSource = imageSource("resume", {
+  isDevelopment: import.meta.env.MODE === "development",
+});
+

--- a/apps/shell/src/components/root-layout.tsx
+++ b/apps/shell/src/components/root-layout.tsx
@@ -6,7 +6,8 @@ import {
   type PropsWithChildren,
 } from "react";
 import { Link, NavLink, useLocation } from "react-router-dom";
-import { imageSource, useGoogleAnalyticsStats } from "@mfe/shared";
+import { useGoogleAnalyticsStats } from "@mfe/shared";
+import { getImageSource } from "../utils/get-image-source";
 import { cn } from "@srf/ui";
 import ActivePill from "./active-pill";
 import { useUpdateGaPageViews } from "@/hooks/use-update-ga-page-views";
@@ -46,7 +47,7 @@ export const DEFAULT_ACTIVE_LABEL = "Menu";
 export function getDefaultLogoConfig(): LogoConfig {
   const isDevelopment = import.meta.env.MODE === "development";
   return {
-    logoSrc: imageSource("home", { isDevelopment })("/favicon.svg"),
+    logoSrc: getImageSource("/favicon.svg"),
     alt: "방구석 코딩쟁이",
     text: "방구석 코딩쟁이",
   };

--- a/apps/shell/src/components/root-layout.tsx
+++ b/apps/shell/src/components/root-layout.tsx
@@ -46,7 +46,7 @@ export const DEFAULT_ACTIVE_LABEL = "Menu";
 export function getDefaultLogoConfig(): LogoConfig {
   const isDevelopment = import.meta.env.MODE === "development";
   return {
-    logoSrc: imageSource("/favicon.svg", "home", { isDevelopment }),
+    logoSrc: imageSource("home", { isDevelopment })("/favicon.svg"),
     alt: "방구석 코딩쟁이",
     text: "방구석 코딩쟁이",
   };

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -66,9 +66,9 @@ export const router = createBrowserRouter(
           path: "*",
           element: (
             <NotFoundSection
-              illustrationSrc={imageSource("/404.svg", "home", {
+              illustrationSrc={imageSource("home", {
                 isDevelopment: import.meta.env.MODE === "development",
-              })}
+              })("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/"

--- a/apps/shell/src/router.tsx
+++ b/apps/shell/src/router.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { createBrowserRouter, Outlet, Link } from "react-router-dom";
 import { NotFoundSection } from "@srf/ui";
-import { imageSource } from "@mfe/shared";
+import { getImageSource } from "./utils/get-image-source";
 
 import Layout from "./components/root-layout";
 import BootRedirect from "./components/boot-redirect";
@@ -66,9 +66,7 @@ export const router = createBrowserRouter(
           path: "*",
           element: (
             <NotFoundSection
-              illustrationSrc={imageSource("home", {
-                isDevelopment: import.meta.env.MODE === "development",
-              })("/404.svg")}
+              illustrationSrc={getImageSource("/404.svg")}
               renderLink={() => (
                 <Link
                   to="/"

--- a/apps/shell/src/utils/get-image-source.ts
+++ b/apps/shell/src/utils/get-image-source.ts
@@ -1,0 +1,10 @@
+import { imageSource } from "@mfe/shared";
+
+/**
+ * Shell/Home 앱용 이미지 소스 생성 함수
+ * 개발/프로덕션 환경에 따라 적절한 호스트 URL을 사용합니다.
+ */
+export const getImageSource = imageSource("home", {
+  isDevelopment: import.meta.env.MODE === "development",
+});
+

--- a/packages/shared/src/utils/imageSource.ts
+++ b/packages/shared/src/utils/imageSource.ts
@@ -12,16 +12,26 @@ const mainHost = (app: AppPrefix, options?: HostOptions) => {
   return isDevelopment ? DEV_HOST_URLS[app] : PROD_HOST_URLS[app];
 };
 
-export const imageSource = (
-  src: string,
-  prefix: "portfolio" | "blog" | "home" | "resume",
-  // devUrl: string,
-  options?: HostOptions,
-) => {
-  const hostUrl = mainHost(prefix, options);
+/**
+ * 이미지 소스 URL을 생성하는 커링 함수
+ *
+ * @param prefix - 앱 이름 (portfolio, blog, home, resume)
+ * @param options - 호스트 옵션
+ * @returns 이미지 경로를 받아서 전체 URL을 반환하는 함수
+ *
+ * @example
+ * ```typescript
+ * const blogImageSource = imageSource("blog", { isDevelopment: true });
+ * const url = blogImageSource("/image.png"); // "http://localhost:3001/image.png"
+ * ```
+ */
+export const imageSource =
+  (prefix: "portfolio" | "blog" | "home" | "resume", options?: HostOptions) =>
+  (src: string) => {
+    const hostUrl = mainHost(prefix, options);
 
-  return `${hostUrl}${src}`;
-};
+    return `${hostUrl}${src}`;
+  };
 
 export function assetUrl(
   path: string,

--- a/packages/ui/src/components/base/not-found-section.tsx
+++ b/packages/ui/src/components/base/not-found-section.tsx
@@ -28,7 +28,7 @@ interface NotFoundSectionProps {
  * @example
  * ```tsx
  * <NotFoundSection
- *   illustrationSrc={imageSource("/404.svg", "blog", { isDevelopment })}
+ *   illustrationSrc={imageSource("blog", { isDevelopment })("/404.svg")}
  *   renderLink={() => (
  *     <Link
  *       to="/blog/posts"

--- a/packages/ui/src/components/mdx/index.ts
+++ b/packages/ui/src/components/mdx/index.ts
@@ -4,7 +4,12 @@ export {
   serialize,
   createDefaultSerializeOptions,
 } from "./lib/serializer/serialize";
-export { isExternalLink } from "./lib/utils";
+export {
+  isExternalLink,
+  createProcessImageSource,
+  removePlugin,
+  sanitizeMdxSource,
+} from "./lib/utils";
 export { Image, Link, Video } from "./lib/components/base";
 export { rehypeUnwrapImages, rehypeSkipMermaid } from "./lib/plugins";
 export type {
@@ -14,4 +19,5 @@ export type {
   LinkProps,
   FrontmatterData,
   RehypePlugin,
+  AppName,
 } from "./types";

--- a/packages/ui/src/components/mdx/index.ts
+++ b/packages/ui/src/components/mdx/index.ts
@@ -21,3 +21,4 @@ export type {
   RehypePlugin,
   AppName,
 } from "./types";
+export { APP_NAMES, DEFAULT_APP_NAME } from "./lib/constants";

--- a/packages/ui/src/components/mdx/lib/components/base/Image.tsx
+++ b/packages/ui/src/components/mdx/lib/components/base/Image.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Dialog, DialogTrigger, DialogContent, DialogTitle, cn } from "@srf/ui";
 import { createImageStyle } from "./image-style";
+import type { AppName } from "../../../types";
+import { DEFAULT_APP_NAME } from "../../constants";
 
 interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   source?: string;
@@ -8,8 +10,8 @@ interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   figcaption?: string;
   width?: number | string;
   height?: number | string;
-  processImageSource?: (src: string, appName: string) => string;
-  appName?: string;
+  processImageSource?: (src: string, appName: AppName) => string;
+  appName?: AppName;
 }
 
 export function Image({
@@ -22,7 +24,7 @@ export function Image({
   height,
   className,
   processImageSource,
-  appName = "portfolio",
+  appName = DEFAULT_APP_NAME,
   ...props
 }: ImageProps) {
   const [opened, setOpened] = useState(false);

--- a/packages/ui/src/components/mdx/lib/constants.ts
+++ b/packages/ui/src/components/mdx/lib/constants.ts
@@ -1,4 +1,4 @@
-import type { AppName } from "../../types";
+import type { AppName } from "../types";
 
 /**
  * 앱 이름 상수

--- a/packages/ui/src/components/mdx/lib/constants.ts
+++ b/packages/ui/src/components/mdx/lib/constants.ts
@@ -1,0 +1,17 @@
+import type { AppName } from "../../types";
+
+/**
+ * 앱 이름 상수
+ */
+export const APP_NAMES = {
+  BLOG: "blog",
+  PORTFOLIO: "portfolio",
+  HOME: "home",
+  RESUME: "resume",
+} as const satisfies Record<string, AppName>;
+
+/**
+ * 기본 앱 이름 (fallback용)
+ */
+export const DEFAULT_APP_NAME: AppName = APP_NAMES.PORTFOLIO;
+

--- a/packages/ui/src/components/mdx/lib/utils/image-source.ts
+++ b/packages/ui/src/components/mdx/lib/utils/image-source.ts
@@ -10,7 +10,7 @@ import type { AppName } from "../../types";
  */
 export function createProcessImageSource(
   appName: AppName,
-): (src: string, _appName: AppName) => string {
+): (src: string, appName: AppName) => string {
   return (src: string, _appName: AppName): string => {
     if (isExternalLink(src)) return src;
 

--- a/packages/ui/src/components/mdx/lib/utils/image-source.ts
+++ b/packages/ui/src/components/mdx/lib/utils/image-source.ts
@@ -6,15 +6,19 @@ import type { AppName } from "../../types";
  * 이미지 소스 처리 함수를 생성하는 팩토리 함수
  *
  * @param appName - 앱 이름 (blog, portfolio, home, resume)
+ * @param options - 옵션 객체
+ * @param options.isDevelopment - 개발 환경 여부 (기본값: false)
  * @returns 이미지 소스를 처리하는 함수
  */
 export function createProcessImageSource(
   appName: AppName,
+  options?: { isDevelopment?: boolean },
 ): (src: string, appName: AppName) => string {
+  const isDevelopment = options?.isDevelopment ?? false;
+
   return (src: string, _appName: AppName): string => {
     if (isExternalLink(src)) return src;
 
-    const isDevelopment = import.meta.env.MODE === "development";
     return imageSource(src, appName, { isDevelopment });
   };
 }

--- a/packages/ui/src/components/mdx/lib/utils/image-source.ts
+++ b/packages/ui/src/components/mdx/lib/utils/image-source.ts
@@ -1,0 +1,21 @@
+import { imageSource } from "@mfe/shared";
+import { isExternalLink } from "./utils";
+import type { AppName } from "../../types";
+
+/**
+ * 이미지 소스 처리 함수를 생성하는 팩토리 함수
+ *
+ * @param appName - 앱 이름 (blog, portfolio, home, resume)
+ * @returns 이미지 소스를 처리하는 함수
+ */
+export function createProcessImageSource(
+  appName: AppName,
+): (src: string, _appName: AppName) => string {
+  return (src: string, _appName: AppName): string => {
+    if (isExternalLink(src)) return src;
+
+    const isDevelopment = import.meta.env.MODE === "development";
+    return imageSource(src, appName, { isDevelopment });
+  };
+}
+

--- a/packages/ui/src/components/mdx/lib/utils/image-source.ts
+++ b/packages/ui/src/components/mdx/lib/utils/image-source.ts
@@ -16,10 +16,12 @@ export function createProcessImageSource(
 ): (src: string, appName: AppName) => string {
   const isDevelopment = options?.isDevelopment ?? false;
 
+  const getImageSource = imageSource(appName, { isDevelopment });
+
   return (src: string, _appName: AppName): string => {
     if (isExternalLink(src)) return src;
 
-    return imageSource(src, appName, { isDevelopment });
+    return getImageSource(src);
   };
 }
 

--- a/packages/ui/src/components/mdx/lib/utils/index.ts
+++ b/packages/ui/src/components/mdx/lib/utils/index.ts
@@ -1,1 +1,4 @@
 export { isExternalLink } from "./utils";
+export { createProcessImageSource } from "./image-source";
+export { removePlugin } from "./plugins";
+export { sanitizeMdxSource } from "./sanitize";

--- a/packages/ui/src/components/mdx/lib/utils/plugins.ts
+++ b/packages/ui/src/components/mdx/lib/utils/plugins.ts
@@ -1,0 +1,21 @@
+import type { RehypePlugin } from "../../types";
+
+/**
+ * 플러그인 배열에서 특정 플러그인을 제거하는 유틸리티
+ *
+ * @param plugins - 플러그인 배열
+ * @param targetPlugin - 제거할 대상 플러그인
+ * @returns 대상 플러그인이 제거된 새로운 플러그인 배열
+ */
+export function removePlugin(
+  plugins: RehypePlugin[],
+  targetPlugin: unknown,
+): RehypePlugin[] {
+  return plugins.filter((plugin) => {
+    if (Array.isArray(plugin)) {
+      return plugin[0] !== targetPlugin;
+    }
+    return plugin !== targetPlugin;
+  });
+}
+

--- a/packages/ui/src/components/mdx/lib/utils/sanitize.ts
+++ b/packages/ui/src/components/mdx/lib/utils/sanitize.ts
@@ -1,0 +1,15 @@
+/**
+ * MDX 소스 정제 함수
+ * BOM 제거, 줄바꿈 정규화, 중괄호 이스케이프 처리
+ *
+ * @param src - 원본 MDX 소스 문자열
+ * @returns 정제된 MDX 소스 문자열
+ */
+export function sanitizeMdxSource(src: string): string {
+  return src
+    .replace(/^\uFEFF/, "") // BOM 제거
+    .replace(/\r\n/g, "\n") // Windows 줄바꿈 정규화
+    .replace(/{{/g, "\\{\\{") // 중괄호 이스케이프
+    .replace(/}}/g, "\\}\\}"); // 중괄호 이스케이프
+}
+

--- a/packages/ui/src/components/mdx/types.ts
+++ b/packages/ui/src/components/mdx/types.ts
@@ -1,6 +1,11 @@
 import type { ReactNode, ComponentType } from "react";
 
 /**
+ * 앱 이름 타입
+ */
+export type AppName = "blog" | "portfolio" | "home" | "resume";
+
+/**
  * 링크 컴포넌트의 props 타입
  */
 export interface LinkProps {
@@ -16,10 +21,10 @@ export interface LinkProps {
  */
 export interface RuntimeConfig {
   /** 이미지 소스를 처리하는 함수 */
-  processImageSource: (src: string, appName: string) => string;
+  processImageSource: (src: string, appName: AppName) => string;
 
   /** 앱 이름 (blog, portfolio 등) */
-  appName: string;
+  appName: AppName;
 }
 
 /**


### PR DESCRIPTION
# 홈페이지 UI 간소화

## 변경 사항

포트폴리오 홈페이지의 Hero 섹션과 주요 프로젝트 섹션을 간소화하여 더 깔끔하고 집중된 UI로 개선했습니다.

### 주요 변경사항

1. **Hero 섹션 간소화**
   - 통계 카드 4개 제거 (전체 프로젝트, 프로젝트 그룹, 태그, 주요 프로젝트)
   - 통계 계산 로직 제거 (`useMemo`, `usePortfolioIndex` 사용 제거)
   - 소개 문구와 CTA 버튼만 유지하여 핵심 메시지에 집중

2. **주요 프로젝트 섹션 개선**
   - "Selected Projects" → "주요 프로젝트"로 문구 변경
   - "전체 보기" 링크 제거로 더 간결한 UI

## 목적

- 홈페이지의 정보 과부하를 줄이고 핵심 메시지에 집중
- 불필요한 데이터 로딩 제거로 성능 개선
- 더 깔끔하고 모던한 UI 제공

## 변경된 파일

- `apps/portfolio/src/pages/home/components/hero-section.tsx`
  - 통계 섹션 및 관련 로직 제거
  - CTA 버튼만 유지
- `apps/portfolio/src/pages/home/components/selected-projects.tsx`
  - "전체 보기" 링크 제거
  - 제목만 표시하도록 변경


## 추가 정보

- 통계 정보는 필요시 프로젝트 목록 페이지에서 확인 가능
- Hero 섹션은 이제 소개 문구와 CTA에만 집중하여 더 명확한 사용자 경험 제공

